### PR TITLE
wrapper style3 の背景を修正

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2989,12 +2989,13 @@ input, select, textarea {
 		}
 
 		.wrapper.style3 {
+			background-color: #fff;
 			background-image: url(../../images/nagoyafun1.jpg);
 			color: #8a8686;
 			background-attachment: fixed;
 		background-position: center center;
 		background-repeat: no-repeat;
-		background-size: cover;
+		background-size: contain;
 		}
 
 			.wrapper.style3 strong, .wrapper.style3 b {


### PR DESCRIPTION
@onsentawake 

`background-size: cover;` は画面「全体」を埋めようとします。
スマホサイズは縦のほうが長いので、横長画像は横幅が切り取られてしまいます。
`background-size: contain;` は「画像全体」を画面におさまるようにします。
そういう変更を加えてみました!

![issue](https://user-images.githubusercontent.com/28250432/71544457-fb9d3680-29c2-11ea-9a85-07211d162f85.png)
